### PR TITLE
Configure exposed entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 [![Join the chat at https://gitter.im/auchter/haaska](https://badges.gitter.im/auchter/haaska.svg)](https://gitter.im/auchter/haaska?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-haaska implements a skill adapter to bridge a [Home Assistant](https://home-assistant.io) instance and the Alexa Lighting API. In short, this allows you to control lights, switches, and scenes exposed by your Home Assistant instance using an Amazon Echo.
+haaska implements a skill adapter to bridge a [Home Assistant](https://home-assistant.io) instance and the Alexa Lighting API. Currently, haaska supports the following entity types:
 
-Examples:
-
-- "Alexa, set kitchen to twenty percent"
-- "Alexa, turn on evening scene"
-- "Alexa, turn off bedroom light"
+| Type           | On/Off Supported? | Dim Supported? |
+|----------------|-------------------|----------------|
+| Groups         | Yes               | No             |
+| Input Booleans | Yes               | No             |
+| Lights         | Yes               | Yes            |
+| Media Players  | Yes               | Yes (volume)   |
+| Scenes         | Yes               | No             |
+| Scripts        | Yes               | No             |
+| Switches       | Yes               | No             |
 
 [@brusc](https://github.com/brusc) put together a good [video](https://www.youtube.com/watch?v=zZuwQ9spPkQ) which demonstrates haaska in action, and provides a walkthrough of the setup process.
 
@@ -33,8 +37,56 @@ Examples:
         * Set Client Secret to the previously noted value from Login with Amazon
         * Note the "Redirect URL"
 4. Go back to Login with Amazon and enter the "Redirect URL" as an "Allowed Return URL" for the application you registered.
-5. In the `config/` directory, create a `config.json` file. This file must contain a single object with an `ha_url` key for the API endpoint of your Home Assistant instance, and `ha_passwd` key for the its API password. If you're using HTTPS with a self-signed certificate, put the CA certificate in the `config/` directory and add a `ha_cert` key with the certificate's filename.
+5. In the `config/` directory, copy `config.json.sample` to `config.json`. Below is a listing of properties that `config.json` will accept.
+
+   | Key                   | Example Value                                                                      | Required? | Notes                                                                                            |
+   |-----------------------|------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------|
+   | `ha_url`              | `https://demo.home-assistant.io/api`                                               | **Yes**   | The API endpoint of your Home Assistant instance. This must end in /api (**no trailing slash**). |
+   | `ha_passwd`           | `securepassword`                                                                   | **Yes**   | The API password of your Home Assistant instance.                                                |
+   | `ha_cert`             | `mycert.crt`                                                                       | No        | The name of your self-signed certificate located in the `config/` directory.                     |
+
 6. Send a test event by running `make test`, which will validate that haaska can communicate with your Home Assistant instance. Note that you must have the AWS CLI and [jq](https://stedolan.github.io/jq/) installed.
+
+## Usage
+After completing setup of haaska, tell Alexa: "Alexa, discover my devices". If there is an issue you can go to `Menu / Smart Home` in the [web](http://echo.amazon.com/#smart-home) or mobile app and have Alexa forget all devices and then do the discovery again.
+
+Then you can say "Alexa, Turn on the office light" or whatever name you have given your configured devices.
+
+Here is the table of possible commands to use to tell Alexa what you want to do:
+
+To do this... | Say this...
+--------------|------------
+ON Commands |
+ | Alexa, turn on `<Device Name>`
+ | Alexa, start `<Device Name>`
+ | Alexa, unlock `<Device Name>`
+ | Alexa, open `<Device Name>`
+ | Alexa, boot up `<Device Name>`
+ | Alexa, run `<Device Name>`
+ | Alexa, arm `<Device Name>`
+OFF Commands |
+ | Alexa, turn off `<Device Name>`
+ | Alexa, stop `<Device Name>` (this one is tricky to get right)
+ | Alexa, stop running `<Device Name>` (also very tricky)
+ | Alexa, lock `<Device Name>`
+ | Alexa, close `<Device Name>`
+ | Alexa, shutdown `<Device Name>`
+ | Alexa, shut `<Device Name>`
+ | Alexa, disarm `<Device Name>`
+DIM Commands | `<Position>` is a percentage or a number 1-10
+ | Alexa, brighten `<Device Name>` to `<Position>`
+ | Alexa, dim `<Device Name> to <Position>`
+ | Alexa, raise `<Device Name>` to `<Position>`
+ | Alexa, lower `<Device Name>` to `<Position>`
+ | Alexa, set `<Device Name>` to `<Position>`
+ | Alexa, turn up `<Device Name>` to `<Position>`
+ | Alexa, turn down `<Device Name>` to `<Position>`
+
+To see what Alexa thinks you said, you can see the command history under `Menu / Settings / History` in the [web](http://echo.amazon.com/#settings/dialogs) or mobile app.
+
+To view or remove devices that Alexa knows about, you can go to `Menu / Smart Home` in the [web](http://echo.amazon.com/#smart-home) or mobile app.
+
+(Thanks to [ha-bridge](https://github.com/bwssytems/ha-bridge) for originally writing this section!)
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ haaska implements a skill adapter to bridge a [Home Assistant](https://home-assi
    | `ha_url`              | `https://demo.home-assistant.io/api`                                               | **Yes**   | The API endpoint of your Home Assistant instance. This must end in /api (**no trailing slash**). |
    | `ha_passwd`           | `securepassword`                                                                   | **Yes**   | The API password of your Home Assistant instance.                                                |
    | `ha_cert`             | `mycert.crt`                                                                       | No        | The name of your self-signed certificate located in the `config/` directory.                     |
+   | `ha_allowed_entities` | `["light", "switch", "group", "scene", "media_player", "input_boolean", "script"]` | No        | A JSON array of entity types to expose to Alexa. If not provided, the example value is used.     |
 
 6. Send a test event by running `make test`, which will validate that haaska can communicate with your Home Assistant instance. Note that you must have the AWS CLI and [jq](https://stedolan.github.io/jq/) installed.
 

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -1,4 +1,5 @@
 {
     "ha_url": "http://localhost:8123/api",
-    "ha_passwd": "api_password"
+    "ha_passwd": "api_password",
+    "ha_allowed_entities": ["group", "input_boolean", "light", "media_player", "scene", "script", "switch"]
 }

--- a/haaska.py
+++ b/haaska.py
@@ -124,7 +124,11 @@ def discover_appliances(ha):
         return x['entity_id'].split('.', 1)[0]
 
     def is_supported_entity(x):
-        return entity_domain(x) in ['light', 'switch', 'group', 'scene', 'media_player', 'input_boolean', 'script']
+        allowed_entities = ['group', 'input_boolean', 'light', 'media_player', 'scene', 'script', 'switch']
+        cfg = get_config()
+        if 'ha_allowed_entities' in cfg:
+          allowed_entities = cfg['ha_allowed_entities']
+        return entity_domain(x) in allowed_entities
 
     def is_skipped_entity(x):
         attr = x['attributes']

--- a/haaska.py
+++ b/haaska.py
@@ -28,7 +28,6 @@ from uuid import uuid4
 
 handlers = {}
 
-
 def get_config():
     with open('config.json') as f:
         cfg = json.load(f)
@@ -36,9 +35,9 @@ def get_config():
             cfg['ha_cert'] = False
         return cfg
 
+cfg = get_config()
 
 def event_handler(event, context):
-    cfg = get_config()
     ha = HomeAssistant(cfg['ha_url'], cfg['ha_passwd'], cfg['ha_cert'])
 
     name = event['header']['name']
@@ -125,9 +124,8 @@ def discover_appliances(ha):
 
     def is_supported_entity(x):
         allowed_entities = ['group', 'input_boolean', 'light', 'media_player', 'scene', 'script', 'switch']
-        cfg = get_config()
         if 'ha_allowed_entities' in cfg:
-          allowed_entities = cfg['ha_allowed_entities']
+            allowed_entities = cfg['ha_allowed_entities']
         return entity_domain(x) in allowed_entities
 
     def is_skipped_entity(x):


### PR DESCRIPTION
This adds a new property to `config.json`: `ha_allowed_entities`. It is a JSON array of strings containing the entity types to expose to Alexa.