### PR TITLE
Add Dockerfile & reorder README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2.7
+
+RUN \
+  apt-get update && \
+  apt-get install -y jq zip && \
+  pip install awscli && \
+  apt-get clean && \
+  cd /var/lib/apt/lists && rm -fr *Release* *Sources* *Packages* && \
+  truncate -s 0 /var/log/*log
+
+RUN mkdir -p /usr/src/app
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+CMD ["make"]

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ haaska implements a skill adapter to bridge a [Home Assistant](https://home-assi
 
 ## Setup
 
-1. Run `make` to build a deployable package of haaska. This will generate a `haaska.zip` file that you'll upload to AWS Lambda
-2. Register with an OAuth provider, such as Login with Amazon.
+1. In the `config/` directory, copy `config.json.sample` to `config.json` and update it. [Below](#config-values) is a listing of properties that `config.json` will accept.
+
+1. Run `make` to build a deployable package of haaska. This will generate a `haaska.zip` file that you'll upload to AWS Lambda (if you're used to docker you can try running make with `docker build -t haaska . && docker run -v "$PWD":/usr/src/app haaska`
+1. Register with an OAuth provider, such as Login with Amazon.
     * Note the "Client ID" and "Client Secret", as you'll need those later
-3. Create an Alexa skill and Lambda Function by following [these instructions](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/steps-to-create-a-smart-home-skill) (with the modifications noted below).
+1. Create an Alexa skill and Lambda Function by following [these instructions](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/steps-to-create-a-smart-home-skill) (with the modifications noted below).
     * The name of the Alexa skill doesn't matter, but I'd suggest "haaska"
     * The name of the Lambda function does matter; use "haaska", otherwise you'll need to modify the `FUNCTION_NAME` variable in the `Makefile`.
     * Select `lambda_basic_execution` for the Lambda role
@@ -37,16 +39,16 @@ haaska implements a skill adapter to bridge a [Home Assistant](https://home-assi
         * Set Client Secret to the previously noted value from Login with Amazon
         * Note the "Redirect URL"
     * There are two properly sized Home Assistant logos in the images/ folder which you can upload to Amazon for use with your skill. Upload both on the "Publishing Information" step of the process.
-4. Go back to Login with Amazon and enter the "Redirect URL" as an "Allowed Return URL" for the application you registered.
-5. In the `config/` directory, copy `config.json.sample` to `config.json`. Below is a listing of properties that `config.json` will accept.
+1. Go back to Login with Amazon and enter the "Redirect URL" as an "Allowed Return URL" for the application you registered.
+1. Send a test event by running `make test`, which will validate that haaska can communicate with your Home Assistant instance. Note that you must have the AWS CLI and [jq](https://stedolan.github.io/jq/) installed.
 
-   | Key                   | Example Value                                                                      | Required? | Notes                                                                                            |
-   |-----------------------|------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------|
-   | `ha_url`              | `https://demo.home-assistant.io/api`                                               | **Yes**   | The API endpoint of your Home Assistant instance. This must end in /api (**no trailing slash**). |
-   | `ha_passwd`           | `securepassword`                                                                   | **Yes**   | The API password of your Home Assistant instance.                                                |
-   | `ha_cert`             | `mycert.crt`                                                                       | No        | The name of your self-signed certificate located in the `config/` directory.                     |
+### Config Values
 
-6. Send a test event by running `make test`, which will validate that haaska can communicate with your Home Assistant instance. Note that you must have the AWS CLI and [jq](https://stedolan.github.io/jq/) installed.
+| Key                   | Example Value                                                                      | Required? | Notes                                                                                            |
+|-----------------------|------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------|
+| `ha_url`              | `https://demo.home-assistant.io/api`                                               | **Yes**   | The API endpoint of your Home Assistant instance. This must end in /api (**no trailing slash**). |
+| `ha_passwd`           | `securepassword`                                                                   | **Yes**   | The API password of your Home Assistant instance.                                                |
+| `ha_cert`             | `mycert.crt`                                                                       | No        | The name of your self-signed certificate located in the `config/` directory. |
 
 ## Usage
 After completing setup of haaska, tell Alexa: "Alexa, discover my devices". If there is an issue you can go to `Menu / Smart Home` in the [web](http://echo.amazon.com/#smart-home) or mobile app and have Alexa forget all devices and then do the discovery again.


### PR DESCRIPTION
When I was implementing the skill and testing, I found that using `Docker` to do the `make` and `make test` made things a lot easier for me because I didn't have to manage or install the dependencies - this adds a simple `Dockerfile` based on the version of python that Amazon has available with lambda. 

I also thought that the need to edit the `config`  before running `make` was a bit unclear in the README so this brings that up to the top of the list of steps. 

Awesome Project! 
