### PR TITLE
Exclude Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ haaska implements a skill adapter to bridge a [Home Assistant](https://home-assi
    | `ha_url`              | `https://demo.home-assistant.io/api`                                               | **Yes**   | The API endpoint of your Home Assistant instance. This must end in /api (**no trailing slash**). |
    | `ha_passwd`           | `securepassword`                                                                   | **Yes**   | The API password of your Home Assistant instance.                                                |
    | `ha_cert`             | `mycert.crt`                                                                       | No        | The name of your self-signed certificate located in the `config/` directory.                     |
+   | `excluded_domains`    | `["group", "script"]`                                                              | No        | An array of entity types that you want to be ignored when publishing to the Alexa service.       |
 
 6. Send a test event by running `make test`, which will validate that haaska can communicate with your Home Assistant instance. Note that you must have the AWS CLI and [jq](https://stedolan.github.io/jq/) installed.
 

--- a/haaska.py
+++ b/haaska.py
@@ -129,8 +129,8 @@ def discover_appliances(ha):
     def entity_domain(x):
         return x['entity_id'].split('.', 1)[0]
 
-    def is_supported_entity(x):
-        return entity_domain(x) in ['light', 'switch', 'group', 'scene', 'media_player', 'input_boolean', 'script']
+    def is_supported_entity(x, ha):
+        return entity_domain(x) in ha.supported_domains
 
     def is_skipped_entity(x):
         attr = x['attributes']
@@ -166,7 +166,7 @@ def discover_appliances(ha):
         return o
 
     states = ha.get('states')
-    return [mk_appliance(x) for x in states if is_supported_entity(x) and not
+    return [mk_appliance(x) for x in states if is_supported_entity(x, ha) and not
             is_skipped_entity(x)]
 
 

--- a/haaska.py
+++ b/haaska.py
@@ -41,7 +41,7 @@ def get_config():
 
 def event_handler(event, context):
     cfg = get_config()
-    ha = HomeAssistant(cfg['ha_url'], cfg['ha_passwd'], cfg['ha_cert'])
+    ha = HomeAssistant(cfg['ha_url'], cfg['ha_passwd'], cfg['excluded_domains'], cfg['ha_cert'])
 
     name = event['header']['name']
     payload = event['payload']
@@ -57,11 +57,15 @@ def handle(event):
 
 
 class HomeAssistant(object):
-    def __init__(self, url, passwd, cert=False):
+    def __init__(self, url, passwd, excluded_domains=[], cert=False):
         self.url = url
         self.headers = {'x-ha-access': passwd,
                         'content-type': 'application/json'}
         self.cert = cert
+        self.supported_domains = ['light', 'switch', 'group', 'scene', 'media_player', 'input_boolean', 'script']
+
+        for domain in excluded_domains:
+            self.supported_domains.remove(domain)
 
     def get(self, relurl):
         r = requests.get(self.url + '/' + relurl, headers=self.headers,

--- a/haaska.py
+++ b/haaska.py
@@ -34,6 +34,8 @@ def get_config():
         cfg = json.load(f)
         if 'ha_cert' not in cfg:
             cfg['ha_cert'] = False
+        if 'excluded_domains' not in cfg:
+            cfg['excluded_domains'] = []
         return cfg
 
 


### PR DESCRIPTION
This allows for the ability to exclude whole domains of components.

Haaska supports hiding things via the Home-Assistant customize configs, but if you want whole domains hidden, like groups or scripts, that takes a lot of effort, editing, and maintaining of your configs. It also means every time you add a new `group`, you'll have to remember to customize it.

For example, I have a TON of special groups to help organize things, and I almost never want them available in a first class manner like a speech UI.

Allowing a simple way to ignore full domains of entities makes it nice and simple.
