### PR TITLE
Skip entities which have no friendly_name and haaska_name properties

### DIFF
--- a/haaska.py
+++ b/haaska.py
@@ -133,6 +133,8 @@ def discover_appliances(ha):
         return x['entity_id'].split('.', 1)[0]
 
     def is_supported_entity(x):
+        if 'friendly_name' not in x['attributes'] and 'haaska_name' not in x['attributes']:
+            return False
         allowed_entities = ['group', 'input_boolean', 'light', 'media_player',
                             'scene', 'script', 'switch', 'garage_door', 'lock',
                             'cover']


### PR DESCRIPTION
I had the problem that initially no entities were found by Alexa and the following was logged: `Discovery failed: 'friendly_name'`. Turns out that I have an entity in my local setup where `friendly_name` is not set, for whatever reason.

This PR should skip such entities by simply filtering them. Of course, if there`s a `haaska_name` configured, it should work as this is being used when building the response object for Alexa.