### PR TITLE
Add support for lock control and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ haaska implements a skill adapter to bridge a [Home Assistant](https://home-assi
 | Groups         | Yes               | No             |
 | Input Booleans | Yes               | No             |
 | Lights         | Yes               | Yes            |
+| Locks          | Lock/Unlock       | No             |
 | Media Players  | Yes               | Yes (volume)   |
 | Scenes         | Yes               | No             |
 | Scripts        | Yes               | No             |

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -1,5 +1,5 @@
 {
     "ha_url": "http://localhost:8123/api",
     "ha_passwd": "api_password",
-    "ha_allowed_entities": ["group", "input_boolean", "light", "media_player", "scene", "script", "switch"]
+    "ha_allowed_entities": ["group", "input_boolean", "light", "lock", "media_player", "scene", "script", "switch"]
 }

--- a/haaska.py
+++ b/haaska.py
@@ -166,7 +166,10 @@ def discover_appliances(ha):
             o['friendlyDescription'] = 'Home Assistant ' + \
                 entity_domain(x).replace('_', ' ').title()
         o['isReachable'] = True
-        o['actions'] = ['turnOn', 'turnOff']
+        if entity_domain(x) == 'lock':
+            o['actions'] = ['getLockState', 'setLockState']
+        else:
+            o['actions'] = ['turnOn', 'turnOff']
         if dimmable:
             o['actions'] += ['incrementPercentage', 'decrementPercentage',
                              'setPercentage']
@@ -188,8 +191,8 @@ def control_response(name):
                            'messageId': str(uuid4()),
                            'payloadVersion': '2'}
             try:
-                func(ha, payload)
-                r['payload'] = {'success': True}
+                response_payload = func(ha, payload) or {'success': True}
+                r['payload'] = response_payload
                 return r
             except SmartHomeException as e:
                 return e.r
@@ -216,6 +219,7 @@ def handle_turn_on(ha, payload):
 def handle_turn_off(ha, payload):
     e = mk_entity(ha, payload)
     e.turn_off()
+
 
 @handle('SetPercentageRequest')
 @control_response('SetPercentageConfirmation')
@@ -249,13 +253,35 @@ def handle_percentage_adj(ha, payload, op):
 @handle('IncrementPercentageRequest')
 @control_response('IncrementPercentageConfirmation')
 def handle_increment_percentage(ha, payload):
-    handle_percentage_adj(ha, payload, operator.add)
+    return handle_percentage_adj(ha, payload, operator.add)
 
 
 @handle('DecrementPercentageRequest')
 @control_response('DecrementPercentageConfirmation')
 def handle_decrement_percentage(ha, payload):
-    handle_percentage_adj(ha, payload, operator.sub)
+    return handle_percentage_adj(ha, payload, operator.sub)
+
+
+@handle('GetLockStateRequest')
+def handle_get_lock_state(ha, payload):
+    e = mk_entity(ha, payload)
+    lock_state = e.get_state().upper()
+
+    r = {}
+    r['header'] = {'namespace': 'Alexa.ConnectedHome.Query',
+                   'messageId': str(uuid4()),
+                   'name': 'GetLockStateResponse',
+                   'payloadVersion': '2'}
+    r['payload'] = {'lockState': lock_state}
+    return r
+
+
+@handle('SetLockStateRequest')
+@control_response('SetLockStateConfirmation')
+def handle_set_lock_state(ha, payload):
+    e = mk_entity(ha, payload)
+    e.set_state(payload["lockState"])
+    return {'lockState': payload["lockState"]}
 
 
 class Entity(object):
@@ -281,6 +307,7 @@ class GarageDoorEntity(Entity):
     def turn_off(self):
         self._call_service('garage_door/close')
 
+
 class CoverEntity(Entity):
     def turn_on(self):
         self._call_service('cover/open_cover')
@@ -290,11 +317,16 @@ class CoverEntity(Entity):
 
 
 class LockEntity(Entity):
-    def turn_on(self):
-        self._call_service('lock/lock')
+    def set_state(self, state):
+        if state == "LOCKED":
+            self._call_service('lock/lock')
+        elif state == "UNLOCKED":
+            self._call_service('lock/unlock')
 
-    def turn_off(self):
-        self._call_service('lock/unlock')
+    def get_state(self):
+        state = self.ha.get('states/' + self.entity_id)
+        print(state)
+        return state['state']
 
 
 class ScriptEntity(Entity):


### PR DESCRIPTION
Amazon recently announced a lock control and query API for smart home skills:

https://developer.amazon.com/blogs/post/2cb7be43-749f-497d-aa8c-0607a25938f7/announcing-lock-control-and-query-for-smart-home-skills

This implements support for that API.