### PR TITLE
Add support for input_slider entities

### DIFF
--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -12,6 +12,7 @@
     "fan": "",
     "light": "",
     "input_boolean": ""
+    "input_slider": ""
   },
   "allowed_domains": [
     "climate",
@@ -20,6 +21,7 @@
     "garage_door",
     "group",
     "input_boolean",
+    "input_slider",
     "light",
     "lock",
     "media_player",

--- a/haaska.py
+++ b/haaska.py
@@ -477,6 +477,28 @@ class ToggleEntity(Entity):
         self._call_service('homeassistant/turn_off')
 
 
+class InputSliderEntity(Entity):
+    def get_percentage(self):
+        state = self.ha.get('states/' + self.entity_id)
+        value = state['state']
+        minimum = state['attributes']['minimum']
+        maximum = state['attributes']['maximum']
+        adjusted = value - minimum
+
+        return (adjusted * 100.0 / (maximum - minimum))
+
+    def set_percentage(self, val):
+        state = self.ha.get('states/' + self.entity_id)
+        minimum = state['attributes']['minimum']
+        maximum = state['attributes']['maximum']
+        step = state['attributes']['step']
+        scaled = val * (maximum - minimum) / 100.0
+        rounded = step * round(scaled / step)
+        adjusted = rounded + minimum
+
+        self._call_service('input_slider/select_value', {'value': adjusted})
+
+
 class GarageDoorEntity(ToggleEntity):
     def turn_on(self):
         self._call_service('garage_door/open')
@@ -624,6 +646,7 @@ DOMAINS = {
     'garage_door': GarageDoorEntity,
     'group': ToggleEntity,
     'input_boolean': ToggleEntity,
+    'input_slider': InputSliderEntity,
     'switch': ToggleEntity,
     'fan': FanEntity,
     'cover': CoverEntity,


### PR DESCRIPTION
This represents the entire range of an input slider as a percentage, which means 0% maps to the minimum value of the slider and 100% maps to the maximum value. This may be a little weird if the minimum is not 0, I'm not sure if it's any better to have the percentage be scaled [0 - maximum] and reject values below the minimum though.

Closes #15