### PR TITLE
Fix Makefile for Debian Stretch (stable)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@ SHELL := /bin/bash
 FUNCTION_NAME=haaska
 
 BUILD_DIR=build
+PIP_SYSTEM:=$(shell pip install --help | grep -q -- --system && echo --system)
 
 haaska.zip: haaska.py config/*
 	mkdir -p $(BUILD_DIR)
 	cp $^ $(BUILD_DIR)
-	pip install --system -t $(BUILD_DIR) requests
+	pip install $(PIP_SYSTEM) -t $(BUILD_DIR) requests
 	cd $(BUILD_DIR); zip ../$@ -r *
 
 .PHONY: deploy

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_DIR=build
 haaska.zip: haaska.py config/*
 	mkdir -p $(BUILD_DIR)
 	cp $^ $(BUILD_DIR)
-	pip install -t $(BUILD_DIR) requests
+	pip install --system -t $(BUILD_DIR) requests
 	cd $(BUILD_DIR); zip ../$@ -r *
 
 .PHONY: deploy


### PR DESCRIPTION
Debian 9 introduced patch into pip, which auto-adds "--user" parameter
to pip, which cannot work with "--target". Therefore, "make" fails on
current Debian stable (Stretch, 9). Just adding "--system" before "-t"
fixes that. Yes, it's stupid, but it works. For more info, see:
https://github.com/pypa/pip/issues/3826