### PR TITLE
Catch base Exception instead of bare except

### DIFF
--- a/haaska.py
+++ b/haaska.py
@@ -349,7 +349,7 @@ def supported_features(payload):
     try:
         details = 'additionalApplianceDetails'
         return payload['appliance'][details]['supported_features']
-    except:
+    except Exception:
         return 0
 
 


### PR DESCRIPTION
This fixes the travis build that is currently broken because of a flake violation.